### PR TITLE
bugfix disabling nbextensions for notebook < 4.2

### DIFF
--- a/tests/test_nbextensions_configurator.py
+++ b/tests/test_nbextensions_configurator.py
@@ -100,6 +100,10 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         self.check_extension_enabled(
             'tree', 'nbextensions_configurator/tree_tab/main',
             expected_status=False)
+        self.driver.get(self.base_url())
+        tab_selector = '#tabs a[href$=nbextensions_configurator]'
+        with nt.assert_raises(AssertionError):
+            self.wait_for_selector(tab_selector)
 
     @classmethod
     def check_extension_enabled(cls, section, require, expected_status=True,


### PR DESCRIPTION
where we need to remove the key from load_extensions, rather than just setting its value to false, since notebook doesn't respect values of false.

fixes https://github.com/ipython-contrib/IPython-notebook-extensions/issues/658