### PR TITLE
CI & packaging fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,8 +5,6 @@ message = release {new_version}
 tag = False
 tag_name = {new_version}
 
-[bumpversion:file:conda.recipe/meta.yaml]
-
 [bumpversion:file:setup.py]
 
 [bumpversion:file:src/jupyter_nbextensions_configurator/__init__.py]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ environment:
       PYTHON_VERSION: '3.4'
       PYTHON_ARCH: '32'
 
-    - TOXENV: 'py35-notebook,codecov'
+    - TOXENV: 'py35-notebook'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35
       PYTHON_VERSION: '3.5'
@@ -73,8 +73,8 @@ test_script:
   # run tox tests
   - '%PYTHON_HOME%\Scripts\tox -e %TOXENV%'
 
-on_success:
-  - '%PYTHON_HOME%\Scripts\tox -e codecov'
+after_test:
+  - cmd: '%PYTHON_HOME%\Scripts\tox -e codecov || (echo "codecov failed :(" && cmd /c "exit /b 0")'
 on_failure:
   - ps: $($env:COVERALLS_REPO_TOKEN = '')
   - ps: $($env:SAUCE_ACCESS_KEY = '')

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -2,18 +2,15 @@
 # For a simple conda install (non bleeding-edge), see the conda-forge recipe at
 # https://github.com/conda-forge/jupyter_nbextensions_configurator-feedstock
 
-{% set version = '0.2.1' %}
-
 package:
   name: jupyter_nbextensions_configurator
-  version: {{ version }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   git_url: ../
-  git_tag: {{ version }}
 
 build:
-  number: 0
+  number: {{ GIT_DESCRIBE_NUMBER }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ commands =
 skip_install = true
 deps = coveralls
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coveralls []
 
@@ -89,7 +89,7 @@ skip_install = true
 deps =
     codecov
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coverage xml --ignore-errors
     codecov []
@@ -106,7 +106,7 @@ commands =
     ; tox doesn't run commands through a shell (makes windows inconsistent)
     ; So to get wildcard expansion, run through bash.
     ; Travis is the only place this env should be run, so it's ok to use bash.
-    bash -c \"coverage combine */.coverage\"
+    bash -c \"coverage combine --append */.coverage\"
     coverage report
     coveralls
 
@@ -114,7 +114,7 @@ commands =
 skip_install = true
 deps = coverage
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coverage html
 


### PR DESCRIPTION
* use `coverage combine` with `--append` flag, required since 4.2
* fix appveyor py35 env to match others
* attempt to get appveyor to pass even if codecov fails
* make conda recipe use git-based version & build number