### PR TITLE
Fixing a small bug

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -180,9 +180,11 @@ def load_jupyter_server_extension(nbapp):
     # ensure our template gets into search path
     templates_dir = os.path.join(os.path.dirname(__file__), 'templates')
     nbapp.log.debug('  Editing template path to add {}'.format(templates_dir))
-    searchpath = webapp.settings['jinja2_env'].loader.searchpath
-    if templates_dir not in searchpath:
-        searchpath.append(templates_dir)
+    rootloader = webapp.settings['jinja2_env'].loader
+    for loader in getattr(rootloader, 'loaders', [rootloader]):
+        if hasattr(loader, 'searchpath') and \
+                templates_dir not in loader.searchpath:
+            loader.searchpath.append(templates_dir)
 
     base_url = webapp.settings['base_url']
 


### PR DESCRIPTION
When running JupyterHub under Python 3.5 I get this Error:

```
[W 2016-08-22 09:47:23.889 cvista notebookapp:1054] Error loading server extension jupyter_nbextensions_configurator
    Traceback (most recent call last):
      File "/opt/contovista/ext/miniconda2/envs/py3/lib/python3.5/site-packages/notebook/notebookapp.py", line 1049, in init_server_extensions
        func(self)
      File "/opt/contovista/ext/miniconda2/envs/py3/lib/python3.5/site-packages/jupyter_nbextensions_configurator/__init__.py", line 183, in load_jupyter_server_extension
        searchpath = webapp.settings['jinja2_env'].loader.searchpath
    AttributeError: 'ChoiceLoader' object has no attribute 'searchpath'
```