### PR TITLE
[in jupyterhub tests] use v>=0.7 with altered mocking functions

### DIFF
--- a/tests/nbextensions_test_base.py
+++ b/tests/nbextensions_test_base.py
@@ -100,6 +100,9 @@ class NbextensionTestBase(NotebookTestBase):
             base_url=cls.url_prefix,
             config=cls.config,
         )
+        # disable auth-by-default, introduced in notebook PR #1831
+        if 'token' in NotebookApp.class_trait_names():
+            kwargs['token'] = ''
         kwargs.update(overrides)
         return kwargs
 

--- a/tests/test_jupyterhub.py
+++ b/tests/test_jupyterhub.py
@@ -34,7 +34,7 @@ else:
             'could not import jupyterhub, so skipping jupyterhub tests')
     from jupyterhub.auth import Authenticator
     from jupyterhub.spawner import LocalProcessSpawner
-    from jupyterhub.tests.mocking import MockHub, public_url, user_url
+    from jupyterhub.tests.mocking import MockHub, public_url
     from jupyterhub.utils import random_port
 
 
@@ -129,7 +129,7 @@ class JupyterHubConfiguratorTest(ConfiguratorTest):
 
     @classmethod
     def base_url(cls):
-        return user_url(cls.user, cls.app)
+        return public_url(cls.app, cls.user)
 
     @classmethod
     def setup_class(cls):

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv = *
 usedevelop = false
 deps =
     coverage
-    jupyterhub: jupyterhub
+    jupyterhub: jupyterhub>=0.7
     mock
     nose
     notebook40: notebook>=4.0,<4.1


### PR DESCRIPTION
switch to using mocking.public_url in place of mocking.user_url, which was removed in jupyterhub 26b00578a151ee6925e4d96e549bcd13834afbbc, part of version 0.7.0