### PR TITLE
[CI] test newer versions of python and notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,20 @@ matrix:
       python: '3.4'
       env: TOXENV=py34-notebook42
     - os: linux
+      python: '3.4'
+      env: TOXENV=py34-notebook43
+    - os: linux
+      python: '3.4'
+      env: TOXENV=py34-notebook44
+    - os: linux
+      python: '3.5'
+      env: TOXENV=py35-notebook50
+    - os: linux
       python: '3.5'
       env: TOXENV=py35-notebook
+    - os: linux
+      python: '3.6'
+      env: TOXENV=py36-notebook
     - os: linux
       python: '3.4'
       env: TOXENV=pypy-notebook
@@ -62,6 +74,7 @@ matrix:
     - env: TOXENV=appveyorartifacts
     - env: TOXENV=lint
     - env: TOXENV=pypy-notebook
+    - env: TOXENV=py35-notebook50
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,24 @@ environment:
       PYTHON_VERSION: '3.4'
       PYTHON_ARCH: '32'
 
+    - TOXENV: 'py34-notebook42'
+      TOXPYTHON: C:\Python34\python.exe
+      PYTHON_HOME: C:\Python34
+      PYTHON_VERSION: '3.4'
+      PYTHON_ARCH: '32'
+
+    - TOXENV: 'py34-notebook43'
+      TOXPYTHON: C:\Python34\python.exe
+      PYTHON_HOME: C:\Python34
+      PYTHON_VERSION: '3.4'
+      PYTHON_ARCH: '32'
+
+    - TOXENV: 'py34-notebook44'
+      TOXPYTHON: C:\Python34\python.exe
+      PYTHON_HOME: C:\Python34
+      PYTHON_VERSION: '3.4'
+      PYTHON_ARCH: '32'
+
     - TOXENV: 'py34-notebook4x'
       TOXPYTHON: C:\Python34\python.exe
       PYTHON_HOME: C:\Python34

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ basepython =
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
     {docs,spell}: {env:TOXPYTHON:python2.7}
     {appveyorartifacts,bump,check,clean,codecov,condarecipe,coveralls,jupyterhub,lint,report,pypi_build,pypi_upload}: {env:TOXPYTHON:python3.4}
 setenv =
@@ -31,7 +32,10 @@ deps =
     notebook40: notebook>=4.0,<4.1
     notebook41: notebook>=4.1,<4.2
     notebook42: notebook>=4.2,<4.3
+    notebook43: notebook>=4.3,<4.4
+    notebook44: notebook>=4.4,<4.5
     notebook4x: https://github.com/jupyter/notebook/archive/4.x.zip
+    notebook50: https://github.com/jupyter/notebook/archive/5.0.0b1.zip
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
     requests


### PR DESCRIPTION
* no python3.6 support on appveyor yet
* don't build notebook 5.0.0b1 on appveyor either, as we can't allow failures