### PR TITLE
New features!

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -162,13 +162,8 @@ class NBExtensionHandlerPage(IPythonHandler):
     @web.authenticated
     def get(self):
         """Render the nbextension configuration interface."""
-        nbapp_webapp = self.application
-        nbextension_dirs = nbapp_webapp.settings['nbextensions_path']
-        extension_list = get_configurable_nbextensions(
-            nbextension_dirs=nbextension_dirs, log=self.log)
         self.finish(self.render_template(
             'nbextensions_configurator.html',
-            extension_list_json=json.dumps(extension_list),
             page_title='Nbextensions Configuration',
             **self.application.settings
         ))

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
@@ -139,7 +139,7 @@
     border-bottom-left-radius: 2px;
 }
 
-.input-group .nbext-list-btn-add {
+.nbext-list-wrap > .input-group > .btn {
     font-size: inherit;
 }
 

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
@@ -21,11 +21,19 @@
     display: none;
 }
 
+.nbextensions-configurator-container {
+    margin-top: 4px;
+}
+
 /* styles for the nbextension-selector nav links */
 
 .nbext-selector {
     border-bottom: 1px solid #888;
     padding-bottom: 1em;
+}
+
+.nbext-selector-loading {
+    text-align: center;
 }
 
 .nbext-selector > nav > .nav > li {

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.css
@@ -109,10 +109,13 @@
 
 .nbext-icon,
 .nbext-desc,
-.nbext-compat-div,
 .nbext-enable-btns,
 .nbext-params {
     margin-bottom: 8px;
+}
+
+.nbext-enable-btns {
+    margin-top: 8px;
 }
 
 /* styles for list inputs */

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -6,8 +6,8 @@ define([
     'services/config',
     'base/js/dialog',
     'notebook/js/quickhelp',
-    'nbextensions/nbextensions_configurator/render/render',
-    'nbextensions/nbextensions_configurator/kse_components',
+    './render/render',
+    './kse_components',
     // only loaded, not used:
     'jqueryui',
     'bootstrap'

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -2,10 +2,8 @@ define([
     'jquery',
     'require',
     'base/js/namespace',
-    'base/js/page',
     'base/js/utils',
     'services/config',
-    'base/js/events',
     'base/js/dialog',
     'notebook/js/quickhelp',
     'nbextensions/nbextensions_configurator/render/render',
@@ -17,10 +15,8 @@ define([
     $,
     require,
     Jupyter,
-    page,
     utils,
     configmod,
-    events,
     dialog,
     quickhelp,
     rendermd,
@@ -1261,6 +1257,14 @@ define([
      * build html body listing all nbextensions.
      */
     function build_page () {
+        return require([
+            'base/js/page',
+            'base/js/events',
+        ], function (
+            page,
+            events
+        ) {
+
         add_css('./main.css');
         $('body').addClass(page_class);
 
@@ -1284,6 +1288,7 @@ define([
         setTimeout(popstateCallback, 0);
 
         return nbext_config_page;
+        });
     }
 
     /**

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -1137,11 +1137,30 @@ define([
     function build_configurator_ui () {
         var config_ui = $('<div/>')
             .attr('id', 'nbextensions-configurator-container')
+            .addClass('nbextensions-configurator-container')
             .addClass('container');
 
+        var button_sets = $('<div/>')
+            .addClass('nbext-buttons tree-buttons no-padding pull-right')
+            .prependTo(config_ui);
+
+        var ext_buttons = $('<span/>')
+            .attr('id', 'nbextensions_configurator_buttons')
+            .appendTo(button_sets);
+
+        var refresh_button = $('<button/>')
+            .on('click', refresh_configurable_extensions_list)
+            .attr('title', 'Refresh list of nbextensions')
+            .addClass('nbext-button-refreshlist btn btn-default btn-xs')
+            .appendTo(ext_buttons);
+
         var selector = $('<div/>')
-            .addClass('row nbext-row container-fluid nbext-selector')
+            .addClass('row container-fluid nbext-selector')
             .appendTo(config_ui);
+
+        $('<i/>')
+            .addClass('fa fa-refresh')
+            .appendTo(refresh_button);
 
         $('<h3>Configurable nbextensions</h3>').appendTo(selector);
 
@@ -1386,6 +1405,37 @@ define([
     }
 
     /**
+     * Refresh the list of configurable nbextensions
+     */
+    function refresh_configurable_extensions_list () {
+        // remove/unload any existing nbextensions, readme etc
+        var selector_nav = $('.nbext-selector ul').empty();
+        $('.nbext-ext-row').remove();
+        load_readme({readme: undefined});
+        // add a loading indicator
+        $('<div>')
+            .addClass('col-xs-12 nbext-selector-loading')
+            .append('<i class="fa fa-refresh fa-spin fa-3x fa-fw"></i>')
+            .append('<span class="sr-only">Loading...</span>')
+            .appendTo(selector_nav);
+        // do the actual work
+        return load_all_configs().then(function () {
+            var api_url = utils.url_path_join(
+                base_url, 'nbextensions/nbextensions_configurator/list');
+            return utils.promising_ajax(api_url, {
+                cache: false,
+                type: "GET",
+                dataType: "json",
+            });
+        }).then(function (extension_list) {
+            build_extension_list(extension_list);
+        }).then(function () {
+            // remove loading indicator
+            $('.nbext-selector ul .nbext-selector-loading').remove();
+        });
+    }
+
+    /**
      * Add CSS file to page
      *
      * @param name filename
@@ -1402,6 +1452,7 @@ define([
         build_page : build_page,
         build_configurator_ui : build_configurator_ui,
         build_extension_list : build_extension_list,
-        load_all_configs : load_all_configs
+        load_all_configs : load_all_configs,
+        refresh_configurable_extensions_list : refresh_configurable_extensions_list
     };
 });

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -1270,20 +1270,16 @@ define([
 
         // prepare for rendermd usage
         rendermd.add_markdown_css();
-
-        build_configurator_ui().appendTo('#site');
-
         nbext_config_page.show_header();
+        build_configurator_ui().appendTo('#site');
         events.trigger('resize-header.Page');
 
-        load_all_configs().then(function () {
-            // get list of nbextensions from value set by script embedded in page by the python backend
-            build_extension_list(window.extension_list);
             nbext_config_page.show();
-        });
-
+        
+        refresh_configurable_extensions_list().then(function () {
         window.addEventListener('popstate', popstateCallback);
         setTimeout(popstateCallback, 0);
+        });
 
         return nbext_config_page;
         });

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -602,7 +602,7 @@ define([
                 selector_link: $(),
             };
             var warning = $('<div/>')
-                .addClass('alert alert-warning')
+                .addClass('col-xs-12 alert alert-warning')
                 .appendTo(extension.ui);
             $('<p/>')
                 .text('No nbextensions match the applied filters!')
@@ -806,7 +806,7 @@ define([
              * to ensure the name takes up a whole row-width on its own,
              * so that the subsequent columns wrap onto a new line.
              */
-            var ext_name_head = $('<h3>')
+            $('<h3>')
                 .addClass('col-xs-12')
                 .html(extension.Name)
                 .appendTo(ext_row);
@@ -855,7 +855,7 @@ define([
                     'Check the jupyter server log for the paths of the relevant',
                     'yaml files.'].join(' '));
                 $('<div/>')
-                    .addClass('alert alert-warning')
+                    .addClass('col-xs-12 alert alert-warning')
                     .css('margin-top', '5px')
                     .append(duplicate_warning_p)
                     .appendTo(ext_row);
@@ -952,7 +952,7 @@ define([
             var msg = log_prefix + ' error loading ' + extension.require;
             console.error(msg + ':\n' + err);
             $('<div/>')
-                .addClass('alert alert-warning')
+                .addClass('col-xs-12 alert alert-warning')
                 .css('margin-top', '5px')
                 .append($('<p/>').text(msg))
                 .appendTo(ext_row);
@@ -997,7 +997,7 @@ define([
         });
         $(to_hide).slideUp(100);
         to_show = $(to_show); // convert to jquery obj
-        to_show.slideDown(100)
+        to_show.slideDown(100);
         // make sure a visible nbextensions is selected
         if (!to_show.is('.active')) {
             var candidate = to_show.filter(':not(.disabled)').first().children('a');
@@ -1033,7 +1033,7 @@ define([
     function filter_register_new_tag (new_tag_object) {
         for (var ii=0; ii < tags.length; ii++) {
             if (tags[ii].value == new_tag_object.value && tags[ii].category == new_tag_object.category) {
-                return //tag already exists, so don't insert
+                return; // tag already exists, so don't insert again
             }
         }
         new_tag_object.label = new_tag_object.category + ': ' + new_tag_object.value;
@@ -1142,7 +1142,7 @@ define([
 
         $('<h3>Configurable nbextensions</h3>').appendTo(selector);
 
-        var showhide = $('<div/>')
+        $('<div/>')
             .addClass('nbext-showhide-incompat')
             .append(
                 build_param_input({
@@ -1159,7 +1159,7 @@ define([
 
         filter_build_ui().appendTo(selector);
 
-        var selector_nav = $('<nav/>')
+        $('<nav/>')
             .addClass('row')
             .append('<ul class="nav nav-pills"/>')
             .appendTo(selector);
@@ -1288,8 +1288,6 @@ define([
             }
         }
 
-        var container = $('#site > .container');
-
         var selector_nav = $('.nbext-selector ul');
 
         // sort nbextensions alphabetically
@@ -1370,8 +1368,8 @@ define([
 
         // en/disable incompatible nbextensions
         var hide_incompat = true;
-        if (configs['common'].data.hasOwnProperty('nbext_hide_incompat')) {
-            hide_incompat = configs['common'].data.nbext_hide_incompat;
+        if (configs.common.data.hasOwnProperty('nbext_hide_incompat')) {
+            hide_incompat = configs.common.data.nbext_hide_incompat;
             console.log(log_prefix,
                 'nbext_hide_incompat loaded from config as: ',
                 hide_incompat

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -348,7 +348,7 @@ define([
      * wrap a single list-element input with the <li>, and move/remove buttons
      */
     function wrap_list_input (list_input) {
-        var btn_remove = $('<a/>', {'class': 'btn btn-default input-group-addon nbext-list-el-btn-remove'});
+        var btn_remove = $('<a/>', {'class': 'btn btn-default input-group-addon'});
         btn_remove.append($('<i/>', {'class': 'fa fa-fw fa-trash'}));
         btn_remove.on('click', function () {
             var list_el = $(this).closest('li');
@@ -432,7 +432,7 @@ define([
 
                 // add a button to add list elements
                 var add_button = $('<a/>')
-                    .addClass('btn btn-default input-group-btn nbext-list-btn-add')
+                    .addClass('btn btn-default input-group-btn')
                     .text(' new item')
                     .prepend('<i class="fa fa-plus"/>')
                     .on('click', function () {
@@ -527,8 +527,8 @@ define([
      */
     function load_readme (extension) {
         var readme = $('.nbext-readme');
-        var readme_contents = readme.children('.nbext-readme-contents').empty();
-        var readme_title = readme.find('.nbext-readme-title').empty();
+        var readme_contents = readme.children('.panel-body').empty();
+        var readme_title = readme.children('.panel-heading').children('span').empty();
 
         if (extension.readme === undefined) {
             readme.slideUp(100);
@@ -913,13 +913,11 @@ define([
             // Section
             $('<div/>')
                 .text('section: ' + extension.Section)
-                .addClass('nbext-sect')
                 .appendTo(col_left);
 
             // Require
             $('<div/>')
                 .text('require path: ')
-                .addClass('nbext-req')
                 .append(
                     $('<span/>').addClass('rendered_html').append(
                         $('<code/>').text(extension.require)))
@@ -962,7 +960,6 @@ define([
                     extension.Parameters[ii].section = extension.Section;
                 }
                 var reset_control = $('<a/>')
-                    .addClass('nbext-params-reset')
                     .on('click', reset_params_callback)
                     .addClass('pull-right')
                     .attr({
@@ -1184,7 +1181,7 @@ define([
             .prependTo(config_ui);
 
         var ext_buttons = $('<span/>')
-            .attr('id', 'nbextensions_configurator_buttons')
+            .addClass('btn-group')
             .appendTo(button_sets);
 
         var refresh_button = $('<button/>')
@@ -1233,10 +1230,10 @@ define([
             .appendTo(config_ui);
         $('<div class="panel-heading"/>')
             .append('<i class="fa fa-fw fa-caret-down"/>')
-            .append('<span class="nbext-readme-title">')
+            .append('<span>')
             .on('click', panel_showhide_callback)
             .appendTo(readme);
-        $('<div class="nbext-readme-contents panel-body"/>')
+        $('<div class="panel-body"/>')
             .appendTo(readme);
 
         return config_ui;

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -852,8 +852,8 @@ define([
                     'If they are different, only one will be loaded by the',
                     'notebook, and this may prevent configuration from working',
                     'correctly.',
-                    'Check the jupyter server log for the paths of the relevant',
-                    'yaml files.'].join(' '));
+                    'Check the jupyter notebook server log for the paths of',
+                    'the relevant yaml files.'].join(' '));
                 $('<div/>')
                     .addClass('col-xs-12 alert alert-warning')
                     .css('margin-top', '5px')
@@ -926,7 +926,10 @@ define([
                     .addClass('nbext-params-reset')
                     .on('click', reset_params_callback)
                     .addClass('pull-right')
-                    .attr('href', '#')
+                    .attr({
+                        href: '#',
+                        title:'reset parameters to defaults',
+                    })
                     .text(' reset');
                 $('<i/>')
                     .addClass('fa fa-refresh')
@@ -1276,9 +1279,10 @@ define([
         // add any remaining unconfigurable nbextensions as stubs
         for (section in configs) {
             for (var require_url in unconfigurable_enabled_extensions[section]) {
+                var word = unconfigurable_enabled_extensions[section][require_url] ? 'enabled' : 'disabled';
                 extension_list.push({
                     Name: require_url,
-                    Description: 'This nbextension is enabled in the ' + section + ' json config, ' +
+                    Description: 'This nbextension is ' + word + ' in the ' + section + ' json config, ' +
                         "but doesn't provide a yaml file to tell us how to configure it. " +
                         "You can still enable or disable it from here, though.",
                     Section: section,

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -5,11 +5,13 @@ define([
     'base/js/page',
     'base/js/security',
     'notebook/js/mathjaxutils',
-    'notebook/js/codemirror-ipythongfm',
+    'components/marked/lib/marked',
     'codemirror/lib/codemirror',
-    'codemirror/mode/gfm/gfm',
+    // CodeMirror modules below don't export anything, just loading them does everything necessary
     'codemirror/addon/runmode/runmode',
-    'components/marked/lib/marked'
+    'codemirror/mode/gfm/gfm',
+    'notebook/js/codemirror-ipython',
+    'notebook/js/codemirror-ipythongfm'
 ], function(
     require,
     $,
@@ -17,11 +19,14 @@ define([
     page,
     security,
     mathjaxutils,
-    ipgfm,
+    marked,    
     CodeMirror,
-    gfm,
-    runMode,
-    marked
+    // CodeMirror modules below don't export anything, so will be undefined,
+    // but are included as params for completeness
+    CodeMirror_runMode,
+    CodeMirror_mode_gfm,
+    CodeMirror_mode_ipython,
+    CodeMirror_mode_ipythongfm
 ){
     'use strict';
 

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -87,11 +87,11 @@ define([
                     callback(null, el.innerHTML);
                 } catch (err) {
                     console.log(log_prefix, "Failed to highlight", lang, "code:", err);
-                    callback(err, code);
+                    callback(null, code);
                 }
             }, function (err) {
                 console.log(log_prefix, "Error getting CodeMirror", lang, "mode:", err);
-                callback(err, code);
+                callback(null, code);
             });
         }
     };

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -25,6 +25,9 @@ define([
 ){
     'use strict';
 
+    var mod_name = 'jupyter_nbextensions_configurator/render';
+    var log_prefix = '[' + mod_name + ']';
+
     /**
      * Custom marked options,
      * lifted from notebook/js/notebook
@@ -72,7 +75,7 @@ define([
                 var el = document.createElement("div");
                 var mode = CodeMirror.getMode({}, spec);
                 if (!mode) {
-                    console.log("No CodeMirror mode: " + lang);
+                    console.log(log_prefix, "No CodeMirror", lang, "mode");
                     callback(null, code);
                     return;
                 }
@@ -83,11 +86,11 @@ define([
                     }
                     callback(null, el.innerHTML);
                 } catch (err) {
-                    console.log("Failed to highlight " + lang + " code", err);
+                    console.log(log_prefix, "Failed to highlight", lang, "code:", err);
                     callback(err, code);
                 }
             }, function (err) {
-                console.log("No CodeMirror mode: " + lang);
+                console.log(log_prefix, "Error getting CodeMirror", lang, "mode:", err);
                 callback(err, code);
             });
         }

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/main.js
@@ -2,8 +2,6 @@ define(function (require, exports, module) {
     "use strict";
 
     var $ = require('jqueryui');
-    var Jupyter = require('base/js/namespace');
-    var events = require('base/js/events');
     var utils = require('base/js/utils');
     var nbextensions_configurator = require('../main');
     var rendermd = require('../render/render');
@@ -27,7 +25,7 @@ define(function (require, exports, module) {
         var tab_text = 'Nbextensions';
         var tab_id = 'nbextensions_configurator';
 
-        var tab_pane = $('<div/>')
+        $('<div/>')
             .attr('id', tab_id)
             .append(nbextensions_configurator.build_configurator_ui())
             .addClass('tab-pane')

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/main.js
@@ -2,54 +2,20 @@ define(function (require, exports, module) {
     "use strict";
 
     var $ = require('jqueryui');
-    var utils = require('base/js/utils');
     var nbextensions_configurator = require('../main');
     var rendermd = require('../render/render');
-
-    var base_url = utils.get_body_data('baseUrl');
-    var api_url = utils.url_path_join(base_url, 'nbextensions/nbextensions_configurator/list');
-
-    function refresh_configurable_extensions_list() {
-        return nbextensions_configurator.load_all_configs().then(function () {
-            return utils.promising_ajax(api_url, {
-                cache: false,
-                type: "GET",
-                dataType: "json",
-            });
-        }).then(function (extension_list) {
-            nbextensions_configurator.build_extension_list(extension_list);
-        });
-    }
 
     function insert_tab () {
         var tab_text = 'Nbextensions';
         var tab_id = 'nbextensions_configurator';
 
+        var configurator_ui = nbextensions_configurator.build_configurator_ui();
+        
         $('<div/>')
             .attr('id', tab_id)
-            .append(nbextensions_configurator.build_configurator_ui())
+            .append(configurator_ui)
             .addClass('tab-pane')
             .appendTo('.tab-content');
-
-        var tab_buttons = $('<div/>')
-            .addClass('no-padding tree-buttons pull-right')
-            .prependTo(tab_pane.find('.nbext-selector'));
-
-        var ext_buttons = $('<span/>')
-            .attr('id','nbextensions_configurator_buttons')
-            .appendTo(tab_buttons);
-
-        var refresh_button = $('<button/>')
-            .attr({
-                id: 'refresh_nbextensions_configurator_list',
-                title:'Refresh nbextensions list'
-            })
-            .addClass('btn btn-default btn-xs')
-            .appendTo(ext_buttons);
-
-        $('<i/>')
-            .addClass('fa fa-refresh')
-            .appendTo(refresh_button);
 
         var tab_link = $('<a>')
             .text(tab_text)
@@ -80,7 +46,7 @@ define(function (require, exports, module) {
         rendermd.add_markdown_css();
 
         insert_tab();
-        refresh_configurable_extensions_list();
+        nbextensions_configurator.refresh_configurable_extensions_list();
     }
 
     return {

--- a/src/jupyter_nbextensions_configurator/templates/nbextensions_configurator.html
+++ b/src/jupyter_nbextensions_configurator/templates/nbextensions_configurator.html
@@ -7,9 +7,8 @@
 {% endblock %}
 
 {% block params %}
-
+{{super()}}
 data-base-url="{{base_url | urlencode}}"
-
 {% endblock %}
 
 {% block headercontainer %}
@@ -26,19 +25,12 @@ data-base-url="{{base_url | urlencode}}"
 {% block header %}
 {% endblock %}
 
-{% block site %}
-{% endblock %}
-
 {% block script %}
 
 	{{super()}}
 
 	<script type="text/javascript">
-    	sys_info = {{sys_info|safe}};
-	</script>
-
-	<script type="text/javascript">
-		extension_list = {{extension_list_json|safe}};
+		sys_info = {{sys_info|safe}};
 	</script>
 
 	<script type="text/javascript" charset="utf-8">

--- a/tests/nbextensions_test_base.py
+++ b/tests/nbextensions_test_base.py
@@ -321,3 +321,13 @@ class SeleniumNbextensionTestBase(NbextensionTestBase):
             '{!r} found in {}s').format(message, link_text, timeout)
         return cls.wait_for_element((By.PARTIAL_LINK_TEXT, link_text),
                                     message=message, timeout=timeout)
+
+    @classmethod
+    def wait_for_xpath(cls, xpath, message='', timeout=5):
+        """WebDriverWait for a selector to appear, fail test on timeout."""
+        if message:
+            message += '\n'
+        message = '{}No element matching xpath {!r} found in {}s'.format(
+            message, xpath, timeout)
+        return cls.wait_for_element(
+            (By.XPATH, xpath), message=message, timeout=timeout)

--- a/tests/test_nbextensions_configurator.py
+++ b/tests/test_nbextensions_configurator.py
@@ -138,7 +138,7 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
     def test_11_allow_configuring_incompatibles(self):
         require = 'balrog/daemon'
         # allow configuring incompatibles
-        showhide_sel = '#input_nbext_hide_incompat'
+        showhide_sel = '#nbext_hide_incompat'
         self.wait_for_selector(
             showhide_sel,
             'potentially incompatible nbextenions should show checkbox')

--- a/tests/test_nbextensions_configurator.py
+++ b/tests/test_nbextensions_configurator.py
@@ -175,6 +175,7 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         self.wait_for_selector(sel_dialog, 'a confirmation dialog should show')
         self.driver.find_element_by_css_selector(sel_dialog).click()
         # it should no longer be enabled in config
+        time.sleep(1)
         conf = self.get_config_manager().get(section)
         stat = conf.get('load_extensions', {}).get(require)
         nt.assert_is_none(

--- a/tests/test_nbextensions_configurator.py
+++ b/tests/test_nbextensions_configurator.py
@@ -52,9 +52,8 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
 
     def test_02_body_data_attribute(self):
         nbext_list = self.driver.execute_script('return window.extension_list')
-        nt.assert_is_instance(nbext_list, list)
-        nt.assert_greater(
-            len(nbext_list), 0, 'some nbextensions should be found')
+        # we no longer embed the list into the page
+        nt.assert_is_none(nbext_list)
 
     def test_03_extension_ui_presence(self):
         self.wait_for_selector('.nbext-row', 'an nbextension ui should load')

--- a/tests/test_nbextensions_configurator.py
+++ b/tests/test_nbextensions_configurator.py
@@ -56,7 +56,8 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         nt.assert_is_none(nbext_list)
 
     def test_03_extension_ui_presence(self):
-        self.wait_for_selector('.nbext-row', 'an nbextension ui should load')
+        self.wait_for_selector(
+            '.nbext-ext-row', 'an nbextension ui should load')
         enable_links = self.driver.find_elements_by_css_selector(
             '.nbext-selector')
         nt.assert_greater(
@@ -68,7 +69,7 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         self.wait_for_partial_link_text(partial_txt)
         sel_link = self.driver.find_element_by_partial_link_text(partial_txt)
         sel_link.click()
-        self.wait_for_selector('.nbext-readme-contents img',
+        self.wait_for_selector('.nbext-readme > .panel-body img',
                                'there should be an image in the readme')
 
     def test_05_click_page_readme_link(self):
@@ -94,7 +95,8 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         tab_selector = '#tabs a[href$=nbextensions_configurator]'
         self.wait_for_selector(tab_selector)
         self.driver.find_element_by_css_selector(tab_selector).click()
-        self.wait_for_selector('.nbext-row', 'an nbextension ui should load')
+        self.wait_for_selector(
+            '.nbext-ext-row', 'an nbextension ui should load')
 
     def test_08_disable_tree_tab(self):
         # now disable the appropriate nbextension & wait for update to config
@@ -124,7 +126,7 @@ class ConfiguratorTest(SeleniumNbextensionTestBase):
         section, require = 'notebook', 'balrog/daemon'
         self.set_extension_enabled(section, require, True)
         # refresh the list to check that it appears
-        refresh_selector = '#refresh_nbextensions_configurator_list'
+        refresh_selector = '.nbext-button-refreshlist'
         self.wait_for_selector(refresh_selector)
         refresh = self.driver.find_element_by_css_selector(refresh_selector)
         refresh.click()


### PR DESCRIPTION
 * minor overhaul to parameter input system, storing data in single jquery data key per parameter
 * add ipython highlighting support to markdown renderer
 * Also fix bug preventing display of markdown containing unknown highlighting modes (as discussed in https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/899) 
 * get refreshing the nbextensions list to work correctly (as noted in #29, it currently doesn't do anything). Also use this on the standalone page, allowing the first page-load to skip the nbextensions listing, leaving that to the json api
 * add tooltip for the parameter reset button, as mentioned in #29 
 * update client-side logs to match new server-side logs from #27 
 * minor css fix, remove unused classes