### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,6 @@ matrix:
       env: TOXENV=py34-notebook44
     - os: linux
       python: '3.5'
-      env: TOXENV=py35-notebook50
-    - os: linux
-      python: '3.5'
       env: TOXENV=py35-notebook
     - os: linux
       python: '3.6'
@@ -74,7 +71,6 @@ matrix:
     - env: TOXENV=appveyorartifacts
     - env: TOXENV=lint
     - env: TOXENV=pypy-notebook
-    - env: TOXENV=py35-notebook50
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ before_install:
   - 'if [[ ${TRAVIS_OS_NAME} == "linux" ]] && [[ ${TOXENV} == py* || ${TOXENV} == jupyterhub ]]; then JS_TESTS="true"; else JS_TESTS="false"; fi;'
   - 'echo "\${JS_TESTS}=$JS_TESTS";'
   # for js tests (which we do on linux only), selenium 3 requires geckodriver
-  - 'if [[ ${JS_TESTS} == "true" ]]; then GECKODRIVER_VERSION="0.14.0"; fi;'
+  - 'if [[ ${JS_TESTS} == "true" ]]; then GECKODRIVER_VERSION="0.16.1"; fi;'
   - 'if [[ ${JS_TESTS} == "true" ]]; then wget "https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz"; fi;'
   - 'if [[ ${JS_TESTS} == "true" ]]; then mkdir geckodriver; fi;'
   - 'if [[ ${JS_TESTS} == "true" ]]; then tar -xzf "geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz" -C geckodriver; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 sudo: false
 addons:
   firefox: latest
-  sauce_connect: true
 matrix:
   fast_finish: true
   # Use the built-in venv for linux builds
@@ -79,9 +78,6 @@ env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
-    - SAUCE_USERNAME=nbext_configurator
-    # sauce access key
-    - secure: "QZb4I+/3mFnc826CdstgYTFrmcvIkXiGmp3tkL9FLLPOEN2MHxPauKZ5J0qnzhIkug9mhCz68GBTlxMU4CpfLXWnKNDV85x1H+TI5K2qLaAPFjL9o7DOvAZW5EmMYac3Vgb022iXy/IbmZOjv9jyNzkqCrLqAaWriyo3c0+J6Onj+Q5JG5HjiJqlLhF9/yzsbqhlFmV42MqpZP3PTXEgrJZlwjNYK9DoBrmNg0Oq2rWoa6qMsaVrC0wiDAclx7PQOQRHr/ocbzAmqqSrBhjZdeRnFNiKiuVLfOr4fq5VLKYkFlSNKp91WzVDWKySXf+gp/zzTM5BCIgawuAD5i3z4cM9JqNGEYyod63QNlR6h04jYuUd6Y6y+5fqkx0uW8CiZtLwU8B4aifcNMMpdSg4eGMVnKsOMB/TcNQ9/4ZN2JijjCPk4x0bSYSJmSNcdPtQS39dXVUuVNRAN9fPrmIRAfmS4/MU2BlHz0OlMfxucby2FyYVI1ng8suc8/xRJMws3qrUlO6HYDGzdOko913/m11HCxinunLVCEfo+kLz2RGWz5aZfVUWuSf/D5jKP5GiIKb1wIV6syfOeNzGzEwu2VPuQ2NVlNshVXAi0+mkEqPHIO9yIDoyF2ktTl1KEKGQjPiz57MBRj2Zr8bNx2GigFpeEHkaxEmqyHgNaF7bJ+E="
 before_install:
   - uname -a
   - id -un
@@ -118,11 +114,9 @@ before_install:
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then git fetch --unshallow; fi'
   # also install npm configurable proxy for jupyterhub!
   - 'if [[ ${TOXENV} == "jupyterhub" ]]; then npm install configurable-http-proxy; fi;'
-  # decide ehwether js tests will run
+  # decide whether js tests will run
   - 'if [[ ${TRAVIS_OS_NAME} == "linux" ]] && [[ ${TOXENV} == py* || ${TOXENV} == jupyterhub ]]; then JS_TESTS="true"; else JS_TESTS="false"; fi;'
   - 'echo "\${JS_TESTS}=$JS_TESTS";'
-  # don't need SAUCE if we're not testing js, so disable by clearing env vars
-  - 'if [[ ${JS_TESTS} != "true" ]]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY && echo unset; fi;'
   # for js tests (which we do on linux only), selenium 3 requires geckodriver
   - 'if [[ ${JS_TESTS} == "true" ]]; then GECKODRIVER_VERSION="0.14.0"; fi;'
   - 'if [[ ${JS_TESTS} == "true" ]]; then wget "https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz"; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,15 @@ matrix:
   # Use the built-in venv for linux builds
   # 3.5 as it isn't installed by default. Let tox handle other versions.
   include:
-    #   env: TOXENV=docs
+    # packaging sanity check
     - os: linux
       python: '3.4'
       env: TOXENV=check
+    # python linting
     - os: linux
       python: '3.4'
       env: TOXENV=lint
-    # conda build/install works
+    # check that conda build/install works
     - os: linux
       python: '3.4'
       env: TOXENV=condarecipe
@@ -24,7 +25,7 @@ matrix:
       python: '3.4'
       env: TOXENV=py27-notebook
     - os: linux
-      python: '3.4'
+      python: '3.3'
       env: TOXENV=py33-notebook
     - os: linux
       python: '3.4'
@@ -96,20 +97,23 @@ before_install:
   - 'if [[ ${OSX_PYTHON} ]]; then if [[ $(which python3.4) ]]; then ls -l $(which python3.4); else echo "missing"; fi; fi'
   - 'if [[ ${OSX_PYTHON} ]]; then if [[ $(which python3.5) ]]; then ls -l $(which python3.5); else echo "missing"; fi; fi'
   # stuff for conda recipe
-  - 'if [[ ${TOXENV} == "condarecipe" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi'
+  # Note we're currently installing 4.3.11 specifically, since conda 4.3.14-16
+  # have a bug which stop them intalling anything on travis (see
+  #     https://github.com/conda/conda/issues/5033
+  # for details).
+  # This has been fixed in mewer conda versions
+  # (>=4.3.17), but the current 'latest' installer is still 4.3.14, so we need to specify the
+  # previous version. This should change in future once an installer for
+  # >=4.3.17 is released!
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-4.3.11-Linux-x86_64.sh -O miniconda.sh; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then bash miniconda.sh -b -p $HOME/miniconda; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then hash -r; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda config --set always_yes yes --set changeps1 no; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda info -a; fi  # Useful for debugging any issues with conda'
-  # conda 4.3.14 & conda-build 2.1.6 seem to fail with signals TypError on travis.
-  # conda's auto-update strategy also means that installing or updating anything else will cause
-  # conda to attempt to update itself.
-  # Thus instead of running
-  #    conda update conda
-  # we install conda & conda-build together, specifying the versions that we
-  # wish to avoid
-  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda install "conda!=4.3.14" "conda-build!=2.1.6"; fi'
+  # update conda, this should skip over the problematic 4.3.14-4.3.16 anyway
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda update conda; fi'
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda install conda-build; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda info -a; fi  # Useful for debugging any issues with conda'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then git fetch --unshallow; fi'
   # also install npm configurable proxy for jupyterhub!
@@ -134,7 +138,12 @@ install:
   - virtualenv --version
   - firefox --version
 script:
-  - tox -v -e ${TOXENV}
+  - 'if [[ ${TOXENV} != "condarecipe" ]]; then tox -v -e ${TOXENV}; fi'
+  # don't actually use tox for condarecipe :S
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda config --append channels conda-forge; fi'
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda config --get channels; fi'
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda build conda.recipe/; fi'
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda install --use-local jupyter_nbextensions_configurator; fi'
 after_script:
   # test if TOXENV not in set
   # see http://unix.stackexchange.com/a/111518

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/config_menu/config_menu.yaml
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/config_menu/config_menu.yaml
@@ -2,7 +2,7 @@ Type: Jupyter Notebook Extension
 Name: Nbextensions edit menu item
 Description: Add an edit-menu item to open the nbextensions configurator page
 Main: main.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x
 Icon: icon.png
 tags:
 - configurator

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/tree_tab.yaml
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/tree_tab/tree_tab.yaml
@@ -4,7 +4,7 @@ Description: An nbextension that renders the nbextensions configurator interface
 Link: readme.md
 Main: main.js
 Section: tree
-Compatibility: 4.x
+Compatibility: 4.x, 5.x
 tags:
 - configurator
 - dashboard

--- a/tests/nbextensions_test_base.py
+++ b/tests/nbextensions_test_base.py
@@ -145,6 +145,7 @@ class NbextensionTestBase(NotebookTestBase):
             cls.env_patch = cls.path_patch = Mock(['start', 'stop'])
             cls.home_dir = cls.config_dir = cls.data_dir = Mock(['cleanup'])
             cls.runtime_dir = cls.notebook_dir = Mock(['cleanup'])
+            cls.tmp_dir = Mock(['cleanup'])
         except Exception:
             for func in cls.removal_funcs:
                 func()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -101,11 +101,12 @@ class AppTest(TestCase):
             with open(path, 'r') as f:
                 conf = Config(json.load(f))
             nbapp = conf.get('NotebookApp', {})
-            nt.assert_not_in(
-                'jupyter_nbextensions_configurator',
-                nbapp.get('server_extensions', []),
-                'conf after disable should empty'
-                'server_extensions list'.format(path))
+            if 'server_extensions' in nbapp:
+                nt.assert_not_in(
+                    'jupyter_nbextensions_configurator',
+                    nbapp.server_extensions,
+                    'conf after disable should empty'
+                    'server_extensions list in file {}'.format(path))
             nbservext = nbapp.get('nbserver_extensions', {})
             nt.assert_false(
                 {k: v for k, v in nbservext.items() if v},

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
     requests
-    selenium>=3
+    selenium>=3.4
 commands =
     {posargs:coverage run --parallel-mode --source=src -m nose -vv -a '!uses_jupyterhub' tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     notebook43: notebook>=4.3,<4.4
     notebook44: notebook>=4.4,<4.5
     notebook4x: https://github.com/jupyter/notebook/archive/4.x.zip
-    notebook50: https://github.com/jupyter/notebook/archive/5.0.0b1.zip
+    notebook50: https://github.com/jupyter/notebook/archive/5.0.0.zip
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
     requests


### PR DESCRIPTION
* update nbextensions' compatibility to 5.x
* update tests to using notebook 5.x as new default
* avoid using conda 4.3.14 on travis (it breaks)
* use newer (0.16.1) geckodriver, to work with firefox 53
* require selenium >=3.4, to work with newer geckodriver
* remove travis references to sauce, which we're not using anyway, and is breaking non-PR Travis builds
* add a mock for the new `tmp_dir` attribute on NotebookTestBase