### PR TITLE
Allow utf8 char in yaml files

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -6,6 +6,7 @@
 
 from __future__ import unicode_literals
 
+import io
 import json
 import logging
 import os.path
@@ -66,7 +67,7 @@ def get_configurable_nbextensions(
                     continue
                 yaml_path = os.path.join(direct, filename)
                 yaml_relpath = os.path.relpath(yaml_path, root_nbext_dir)
-                with open(yaml_path, 'r') as stream:
+                with io.open(yaml_path, 'r', encoding='utf-8') as stream:
                     try:
                         extension = yaml.load(stream, Loader=SafeLoader)
                     except yaml.YAMLError:


### PR DESCRIPTION
Use codecs to open yaml file, so that UTF8 char in yaml file can be read properly.