### PR TITLE
Fixes for things broken by notebook 5.1

### DIFF
--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -1296,7 +1296,7 @@ define([
         add_css('./main.css');
         $('body').addClass(page_class);
 
-        var nbext_config_page = Jupyter.page = new page.Page();
+        var nbext_config_page = Jupyter.page = new page.Page('div#header', 'div#site');
 
         // prepare for rendermd usage
         rendermd.add_markdown_css();

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -190,7 +190,7 @@ define([
         // add css first so hopefully it'll be loaded in time
         add_markdown_css();
 
-        page = new page.Page();
+        page = new page.Page('div#header', 'div#site');
         page.show_header();
 
         var base_url = utils.get_body_data('baseUrl');

--- a/src/jupyter_nbextensions_configurator/templates/nbextensions_configurator.html
+++ b/src/jupyter_nbextensions_configurator/templates/nbextensions_configurator.html
@@ -28,12 +28,34 @@ data-base-url="{{base_url | urlencode}}"
 {% block script %}
 
 	{{super()}}
-
 	<script type="text/javascript">
 		sys_info = {{sys_info|safe}};
 	</script>
 
 	<script type="text/javascript" charset="utf-8">
+		// some ugly hacks to fix notebook 5.1.0's broken require config, as
+		// introduced by https://github.com/jupyter/notebook/pull/2140
+		(function () {
+			var nb_v_arr = sys_info.notebook_version.split('.');
+			if (Number(nb_v_arr[0]) == 5 && Number(nb_v_arr[1]) > 0) {
+				console.log(
+					'[nbextensions_configurator] patching requirejs config for notebook',
+					sys_info.notebook_version);
+				require.config({paths: {
+					jed: 'components/jed/jed',
+					json: 'components/requirejs-plugins/src/json',
+					text: 'components/requirejs-text/text',
+					moment: 'components/moment/min/moment-with-locales'
+				}});
+				if (!require.defined('json!base/../../i18n/nbjs.json')) {
+					define('json!base/../../i18n/nbjs.json', function() { return {
+						"domain": "nbjs",
+						"supported_languages": [],
+						"locale_data": {"nbjs": {"": {"domain": "nbjs"}}}
+					}; });
+				}
+			}
+		})(); // end ugly nb 5.1 hacks IIFE
 		require(['jquery'], function (jq) {
 			// hack to fix notebook 4.2.1
 			// see https://github.com/jupyter/notebook/pull/1399

--- a/src/jupyter_nbextensions_configurator/templates/rendermd.html
+++ b/src/jupyter_nbextensions_configurator/templates/rendermd.html
@@ -35,8 +35,32 @@ data-md-url="{{md_url | urlencode}}""
 {% block script %}
 
 	{{super()}}
-
+	<script type="text/javascript">
+		sys_info = {{sys_info|safe}};
+	</script>
+	
 	<script type="text/javascript" charset="utf-8">
+		(function () {
+			var nb_v_arr = sys_info.notebook_version.split('.');
+			if (Number(nb_v_arr[0]) == 5 && Number(nb_v_arr[1]) > 0) {
+				console.log(
+					'[nbextensions_configurator] patching requirejs config for notebook',
+					sys_info.notebook_version);
+				require.config({paths: {
+					jed: 'components/jed/jed',
+					json: 'components/requirejs-plugins/src/json',
+					text: 'components/requirejs-text/text',
+					moment: 'components/moment/min/moment-with-locales'
+				}});
+				if (!require.defined('json!base/../../i18n/nbjs.json')) {
+					define('json!base/../../i18n/nbjs.json', function() { return {
+						"domain": "nbjs",
+						"supported_languages": [],
+						"locale_data": {"nbjs": {"": {"domain": "nbjs"}}}
+					}; });
+				}
+			}
+		})(); // end ugly nb 5.1 hacks IIFE
 		require(['jquery'], function (jq) {
 			// hack to fix notebook 4.2.1
 			// see https://github.com/jupyter/notebook/pull/1399


### PR DESCRIPTION
A couple of things were breaking the standalone page on notebook 5.1, this PR patches the configurator to handle it ok until notebook fixes things upstream (see https://github.com/jupyter/notebook/pull/2887 and https://github.com/jupyter/notebook/pull/2888 for notebook fixes)