### PR TITLE
auto-pad 3-char color codes to 6-char

### DIFF
--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -315,6 +315,13 @@ define([
             case 'checkbox':
                 input.prop('checked', new_value ? true : false);
                 break;
+            case 'color':
+                // for some reason, setting with 3-char color codes doesn't
+                // work correctly, so expand them to 6-char
+                input.val(new_value.replace(
+                    /^\s*#([\da-f])([\da-f])([\da-f])\s*$/i,
+                    '#$1$1$2$2$3$3'));
+                break;
             default:
                 input.val(new_value);
         }


### PR DESCRIPTION
as otherwise setting the html5 control value doesn't work properly