### PR TITLE
Include LICENSE.txt file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ universal = 1
 [flake8]
 ignore = 'I201,I101,D100,D101,D102,D103,D200,D201,D202,D203,D204,D205,D211,D400,D401,D403,N802,N806,'
 
+[metadata]
+license_file = LICENSE.txt
+
 [isort]
 not_skip = __init__.py
 multi_line_output = 5


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.