### PR TITLE
Add _jupyter_nbextension_paths; allow jupyter nbextension install

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -258,6 +258,21 @@ def load_jupyter_server_extension(nbapp):
 
     logger.info('enabled {}'.format(__version__))
 
+def _jupyter_nbextension_paths():
+    return [
+        dict(
+            section="notebook",
+            src="static/nbextensions_configurator",
+            dest="nbextensions_configurator",
+            require='nbextensions_configurator/config_menu/main',
+        ),
+        dict(
+            section="tree",
+            src="static/nbextensions_configurator",
+            dest="nbextensions_configurator",
+            require='nbextensions_configurator/tree_tab/main',
+        ),
+    ]
 
 def _jupyter_server_extension_paths():
     return [{


### PR DESCRIPTION
As detailed in https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/78 right now there is no way to get the jupyter_nbextensions_configurator to correctly register as installed according to `jupyter nbextension list`. 

This enables this functionality by explicitly describing the nbextensions, their sections, their destination names and the path needed for their resources to be found. 