### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Changes
 -----
  * Show error messages when failing to load a config file, allowing remaining
    files to load ok.
- * use pip for conda recipe installation, instead of `python steup.py`
+ * use pip for conda recipe installation, instead of `python setup.py`
 
 0.3.0
 -----


### PR DESCRIPTION
There is a typo in the "Changes" section under version 0.4.0 of the README: `python steup.py` is listed instead of `python setup.py`.