### PR TITLE
Enabling extensions isn't needed anymore for notebook >=5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For those not using conda, the installation has two steps:
     subcommand is provided for this. You can enable the serverextension and the
     configurator nbextensions listed below for the current user with
 
-        jupyter nbextensions_configurator enable --user
+        jupyter nbextensions_configurator enable --user  # can be skipped for notebook >=5.3
 
     The command accepts the same flags as the `jupyter serverextension` command
     provided by notebook versions >= 4.2, including `--system` to enable in

--- a/jupyter-config/jupyter_notebook_config.d/jupyter_nbextensions_configurator.json
+++ b/jupyter-config/jupyter_notebook_config.d/jupyter_nbextensions_configurator.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "jupyter_nbextensions_configurator": true
+    }
+  }
+}

--- a/jupyter-config/nbconfig/notebook.d/jupyter_nbextensions_configurator.json
+++ b/jupyter-config/nbconfig/notebook.d/jupyter_nbextensions_configurator.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "nbextensions_configurator/config_menu/main": true
+  }
+}

--- a/jupyter-config/nbconfig/tree.d/jupyter_nbextensions_configurator.json
+++ b/jupyter-config/nbconfig/tree.d/jupyter_nbextensions_configurator.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "nbextensions_configurator/tree_tab/main": true
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,17 @@ options.
         packages=find_packages('src'),
         package_dir={'': 'src'},
         include_package_data=True,
+        data_files=[
+	    ("etc/jupyter/nbconfig/notebook.d", [
+		"jupyter-config/nbconfig/notebook.d/jupyter_nbextensions_configurator.json"
+	    ]),
+	    ("etc/jupyter/nbconfig/tree.d", [
+		"jupyter-config/nbconfig/tree.d/jupyter_nbextensions_configurator.json"
+	    ]),
+	    ("etc/jupyter/jupyter_notebook_config.d", [
+		"jupyter-config/jupyter_notebook_config.d/jupyter_nbextensions_configurator.json"
+	    ])
+        ],
         py_modules=[
             os.path.splitext(os.path.basename(path))[0]
             for path in glob('src/*.py')


### PR DESCRIPTION
With this change, the conda recipe for the package no longer needs to rely on pre/post link/unlink scripts.