### PR TITLE
Fix unable to load jupyter_nbextensions_configurator extension on Notebook 6.x.x

### DIFF
--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -4,7 +4,7 @@ define([
     'base/js/utils',
     'base/js/page',
     'base/js/security',
-    'notebook/js/mathjaxutils',
+    'base/js/mathjaxutils.js',
     'components/marked/lib/marked',
     'codemirror/lib/codemirror',
     // CodeMirror modules below don't export anything, just loading them does everything necessary


### PR DESCRIPTION
Fix issue #125  and #126 where Jupyter notebook cannot load the jupyter_nbextensions_configurator extension and displays a blank page when navigate to localhost:8888/nbextensions/.

The fix is explained in #125 .