### PR TITLE
Remove the `scripts` portion of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,6 @@ options.
                 'jupyter-nbextensions_configurator = jupyter_nbextensions_configurator.application:main',  # noqa
             ],
         },
-        scripts=[os.path.join('scripts', p) for p in [
-            'jupyter-nbextensions_configurator',
-        ]],
         classifiers=[
             'Intended Audience :: End Users/Desktop',
             'Intended Audience :: Science/Research',


### PR DESCRIPTION
Scripts is deprecated by entry_points and when both exist it causes errors for some PEP-compliant installers.

some details here: https://github.com/bazelbuild/rules_python/issues/765#issuecomment-1193000233