### PR TITLE
Use sys_info.notebook_version to get notebook version

### DIFF
--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -167,7 +167,8 @@ define([
         console.log(log_prefix, state ? ' enabled' : 'disabled', extension.require);
         // for pre-4.2 versions, the javascript loading nbextensions actually
         // ignores the true/false state, so to disable we have to delete the key
-        if ((version_compare(sys_info.notebook_version, '4.2') < 0) && !state) {
+        if ((version_compare(((typeof sys_info === 'undefined') ? Jupyter.version : sys_info.notebook_version),
+            '4.2') < 0) && !state) {
             state = null;
         }
         var to_load = {};
@@ -935,7 +936,7 @@ define([
             // Compatibility
             var compat_txt = extension.Compatibility || '?.x';
             var compat_idx = compat_txt.toLowerCase().indexOf(
-                sys_info.notebook_version.substring(0, 2) + 'x');
+                ((typeof sys_info === 'undefined') ? Jupyter.version : sys_info.notebook_version).substring(0, 2) + 'x');
             if (!extension.is_compatible) {
                 ext_row.addClass('nbext-incompatible');
                 compat_txt = $('<span/>')
@@ -1436,7 +1437,7 @@ define([
             console.log(log_prefix, 'Found nbextension', extension.require);
 
             extension.is_compatible = (extension.Compatibility || '?.x').toLowerCase().indexOf(
-                sys_info.notebook_version.substring(0, 2) + 'x') >= 0;
+                ((typeof sys_info === 'undefined') ? Jupyter.version : sys_info.notebook_version).substring(0, 2) + 'x') >= 0;
             extension.Parameters = extension.Parameters || [];
             if (!extension.is_compatible) {
                 // reveal the checkbox since we've found an incompatible nbext

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -8,7 +8,9 @@ define([
     'notebook/js/quickhelp',
     './render/render',
     './kse_components',
-    'base/js/events'
+    // only loaded, not used:
+    'jqueryui',
+    'bootstrap'
 ], function(
     $,
     require,

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/main.js
@@ -8,9 +8,7 @@ define([
     'notebook/js/quickhelp',
     './render/render',
     './kse_components',
-    // only loaded, not used:
-    'jqueryui',
-    'bootstrap'
+    'base/js/events'
 ], function(
     $,
     require,
@@ -167,7 +165,7 @@ define([
         console.log(log_prefix, state ? ' enabled' : 'disabled', extension.require);
         // for pre-4.2 versions, the javascript loading nbextensions actually
         // ignores the true/false state, so to disable we have to delete the key
-        if ((version_compare(Jupyter.version, '4.2') < 0) && !state) {
+        if ((version_compare(sys_info.notebook_version, '4.2') < 0) && !state) {
             state = null;
         }
         var to_load = {};
@@ -935,7 +933,7 @@ define([
             // Compatibility
             var compat_txt = extension.Compatibility || '?.x';
             var compat_idx = compat_txt.toLowerCase().indexOf(
-                Jupyter.version.substring(0, 2) + 'x');
+                sys_info.notebook_version.substring(0, 2) + 'x');
             if (!extension.is_compatible) {
                 ext_row.addClass('nbext-incompatible');
                 compat_txt = $('<span/>')
@@ -1436,7 +1434,7 @@ define([
             console.log(log_prefix, 'Found nbextension', extension.require);
 
             extension.is_compatible = (extension.Compatibility || '?.x').toLowerCase().indexOf(
-                Jupyter.version.substring(0, 2) + 'x') >= 0;
+                sys_info.notebook_version.substring(0, 2) + 'x') >= 0;
             extension.Parameters = extension.Parameters || [];
             if (!extension.is_compatible) {
                 // reveal the checkbox since we've found an incompatible nbext


### PR DESCRIPTION
As `Jupyter.version` no longer works, use `sys_info.notebook_version` to get the current notebook version.
This requires a change in the notebook `page.html` template to work.
