### PR TITLE
add support for new marked version >=4.0.0 to fix #151 and support nbclassic >=0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ This project was spun out of work from
 Installation
 ------------
 
+> **Note:** `jupyter_nbextensions_configurator` versions > 0.6.1 requires 
+  [notebook](https://github.com/jupyter/notebook) >= 6.5 (and 
+  [nbclasic](https://github.com/jupyter/nbclassic) >= 0.5). To avoid any implicit 
+  update of these two package intall `jupyter_nbextensions_configurator` <= 0.6.1.
+
 For those using conda, you can now get `jupyter_nbextensions_configurator` from
 the excellent [conda-forge](https://conda-forge.github.io/)
 [channel](https://anaconda.org/conda-forge) in a single command:

--- a/README.md
+++ b/README.md
@@ -32,13 +32,11 @@ This project was spun out of work from
 Installation
 ------------
 
-> **Note:** `jupyter_nbextensions_configurator` versions > 0.6.1 requires 
-  [notebook](https://github.com/jupyter/notebook) >= 6.5 (and 
-  [nbclasic](https://github.com/jupyter/nbclassic) >= 0.5). To avoid any implicit 
-  update of these two package intall `jupyter_nbextensions_configurator` <= 0.6.1.
 **Note:** `jupyter_nbextensions_configurator` versions > 0.6.1 requires 
   [notebook](https://github.com/jupyter/notebook) >= 6.5 (and 
-  [nbclassic](https://github.com/jupyter/nbclassic) >= 0.5). For prior versions of notebook or nbclassic, install `jupyter_nbextensions_configurator` <= 0.6.1.
+  [nbclassic](https://github.com/jupyter/nbclassic) >= 0.5). For prior versions of notebook or nbclassic, 
+  install `jupyter_nbextensions_configurator` <= 0.6.1.
+  
 For those using conda, you can now get `jupyter_nbextensions_configurator` from
 the excellent [conda-forge](https://conda-forge.github.io/)
 [channel](https://anaconda.org/conda-forge) in a single command:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Installation
   [notebook](https://github.com/jupyter/notebook) >= 6.5 (and 
   [nbclasic](https://github.com/jupyter/nbclassic) >= 0.5). To avoid any implicit 
   update of these two package intall `jupyter_nbextensions_configurator` <= 0.6.1.
-
+**Note:** `jupyter_nbextensions_configurator` versions > 0.6.1 requires 
+  [notebook](https://github.com/jupyter/notebook) >= 6.5 (and 
+  [nbclassic](https://github.com/jupyter/nbclassic) >= 0.5). For prior versions of notebook or nbclassic, install `jupyter_nbextensions_configurator` <= 0.6.1.
 For those using conda, you can now get `jupyter_nbextensions_configurator` from
 the excellent [conda-forge](https://conda-forge.github.io/)
 [channel](https://anaconda.org/conda-forge) in a single command:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ options.
         install_requires=[
             'jupyter_contrib_core >=0.3.3',
             'jupyter_core',
-            'notebook >=6.0',
+            'notebook >=6.5',
+            'nbclassic >=0.5',
             'pyyaml',
             'tornado',
             'traitlets',

--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -5,7 +5,7 @@ define([
     'base/js/page',
     'base/js/security',
     'notebook/js/mathjaxutils',
-    'components/marked/lib/marked',
+    'components/marked/lib/marked.umd',
     'codemirror/lib/codemirror',
     // CodeMirror modules below don't export anything, just loading them does everything necessary
     'codemirror/addon/runmode/runmode',
@@ -152,7 +152,7 @@ define([
             var text = text_and_math[0];
             var math = text_and_math[1];
             var options = custom_marked_options;
-            marked(text, options, function (err, html) {
+            marked.marked(text, options, function (err, html) {
                 html = mathjaxutils.replace_math(html, math);
                 html = security.sanitize_html(html);
                 html = $($.parseHTML(html));


### PR DESCRIPTION
This fixes `nbclassic >=0.5 breaks jupyter_nbextensions_configurator` #151