### PR TITLE
fix marked loading depending on the host notbeook/nbclassic version

### DIFF
--- a/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
+++ b/src/jupyter_nbextensions_configurator/static/nbextensions_configurator/render/render.js
@@ -33,6 +33,8 @@ define([
     var mod_name = 'jupyter_nbextensions_configurator/render';
     var log_prefix = '[' + mod_name + ']';
 
+    marked = marked.marked || marked;
+
     /**
      * Custom marked options,
      * lifted from notebook/js/notebook


### PR DESCRIPTION
Fixes https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/151

Depending on marked js version, the marked object is loaded via `marked.marked` or `marked`.

<img width="1170" alt="Screenshot 2023-04-13 at 07 48 08" src="https://user-images.githubusercontent.com/226720/231758193-7ad974f5-45f9-4c54-80b2-125e5a3fc5ec.png">
