### PR TITLE
fix: import notebook version from _version

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -14,7 +14,7 @@ import posixpath
 import re
 
 import yaml
-from notebook import version_info as nb_version_info
+from notebook._version import version_info as nb_version_info
 from notebook.base.handlers import APIHandler, IPythonHandler
 from notebook.utils import url_path_join as ujoin
 from notebook.utils import path2url


### PR DESCRIPTION
To support Notebook 6 and NbClassic+Notebook7, we need to import the notebook version from `_version`.