### PR TITLE
Update import for backwards compatibility

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -16,6 +16,7 @@ import re
 import yaml
 try: 
     from notebook.base.handlers import APIHandler
+    # When Notebook < 7 is available, the import the Notebook handlers
     from notebook.base.handlers import IPythonHandler as JupyterHandler
     from notebook.utils import url_path_join as ujoin
     from notebook.utils import path2url

--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -14,9 +14,16 @@ import posixpath
 import re
 
 import yaml
-from jupyter_server.base.handlers import APIHandler, JupyterHandler
-from jupyter_server.utils import url_path_join as ujoin
-from jupyter_server.utils import path2url
+try: 
+    from notebook.base.handlers import APIHandler
+    from notebook.base.handlers import IPythonHandler as JupyterHandler
+    from notebook.utils import url_path_join as ujoin
+    from notebook.utils import path2url
+except ModuleNotFoundError as e:
+    from jupyter_server.base.handlers import APIHandler, JupyterHandler
+    from jupyter_server.utils import url_path_join as ujoin
+    from jupyter_server.utils import path2url
+
 from notebook._version import version_info as nb_version_info
 from tornado import web
 

--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -15,8 +15,8 @@ import re
 
 import yaml
 try: 
-    from notebook.base.handlers import APIHandler
     # When Notebook < 7 is available, the import the Notebook handlers
+    from notebook.base.handlers import APIHandler
     from notebook.base.handlers import IPythonHandler as JupyterHandler
     from notebook.utils import url_path_join as ujoin
     from notebook.utils import path2url


### PR DESCRIPTION
JupyterServer handlers are not compatible with Notebook 6 series, this updates mitigates error that Notebook 6 users installing the latest version of the `jupyter_nbextensions_configurator`, may encounter.