### PR TITLE
Add notebook 7 compatibility

### DIFF
--- a/src/jupyter_nbextensions_configurator/__init__.py
+++ b/src/jupyter_nbextensions_configurator/__init__.py
@@ -26,6 +26,14 @@ try:
 except ImportError:
     from yaml import SafeLoader
 
+if nb_version_info > (7,):
+    from nbclassic import shim_notebook, nbextensions, notebookapp, tests
+    import sys
+    shim_notebook()
+    sys.modules['notebook.nbextensions'] = nbextensions
+    sys.modules['notebook.notebookapp'] = notebookapp
+    sys.modules['notebook.tests'] = tests
+
 if nb_version_info < (5, 2, 0):
     from notebook.base.handlers import json_errors
 else:


### PR DESCRIPTION
In relation to #165, this still did not seem to work `jupyter nbextensions_configurator enable --sys-prefix`